### PR TITLE
update httpcli not to follow

### DIFF
--- a/resource/httpclient/httpclient.go
+++ b/resource/httpclient/httpclient.go
@@ -30,7 +30,13 @@ var defaultHeaders = map[string][]string{"Content-Type": {"application/json"}}
 func New(cfg *config.Resource) (*Client, error) {
 	params := cfg.Params
 
-	client := &Client{new(http.Client), "", nil, defaultHeaders}
+	httpClient := &http.Client{
+		// In order for http client not to follow response redirect
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+	client := &Client{httpClient, "", nil, defaultHeaders}
 	for key, val := range params {
 		switch key {
 		case "base_url":


### PR DESCRIPTION
In order to test endpoint that return redirect, we need httpclient not to follow the request until end of destination ,and just use the first response