### PR TITLE
feat(postgres): add variable interpolation to postgres steps

### DIFF
--- a/internal/handler/postgres.go
+++ b/internal/handler/postgres.go
@@ -229,7 +229,7 @@ func (r *Postgres) setTableValues(table string, data *godog.Table) error {
 	for _, row := range data.Rows[1:] {
 		values := make([]string, len(row.Cells))
 		for i, cell := range row.Cells {
-			values[i] = fmt.Sprintf("'%s'", cell.Value)
+			values[i] = fmt.Sprintf("'%s'", ReplaceVariables(cell.Value))
 		}
 		query := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", table, strings.Join(columns, ", "), strings.Join(values, ", "))
 		if _, err := r.db.Exec(query); err != nil {
@@ -275,8 +275,9 @@ func (r *Postgres) tableShouldContain(table string, expected *godog.Table) error
 			return fmt.Errorf("missing row %d", i+1)
 		}
 		for j, cell := range expectedRow.Cells {
-			if actual[i][j] != cell.Value {
-				return fmt.Errorf("row %d, column %s: expected %q, got %q", i+1, columns[j], cell.Value, actual[i][j])
+			expected := ReplaceVariables(cell.Value)
+			if actual[i][j] != expected {
+				return fmt.Errorf("row %d, column %s: expected %q, got %q", i+1, columns[j], expected, actual[i][j])
 			}
 		}
 	}
@@ -306,7 +307,7 @@ func (r *Postgres) tableShouldHaveRows(table string, expected int) error {
 }
 
 func (r *Postgres) executeSQL(query *godog.DocString) error {
-	_, err := r.db.Exec(query.Content)
+	_, err := r.db.Exec(ReplaceVariables(query.Content))
 	return err
 }
 


### PR DESCRIPTION
## Summary

- Add `{{variable}}` interpolation support to postgres handler steps, matching the behavior already present in the HTTP client handler
- Previously, variables captured via HTTP response steps (e.g. `saved as "{{cr_id}}"`) could not be used in postgres steps — this made it impossible to cross-reference HTTP-created resources with direct database assertions

## What changed

Three postgres handler methods now call `ReplaceVariables()` on their inputs:

- **`executeSQL`** — interpolates docstring content before executing
- **`setTableValues`** — interpolates cell values when inserting rows
- **`tableShouldContain`** — interpolates expected cell values when asserting

## Example

This now works:

```gherkin
# Save an ID from HTTP response
When "api" sends "POST" to "/api/users"
Then "api" response json "id" saved as "{{user_id}}"

# Use it in a postgres assertion
Then "db" table "users" contains:
  | id           | status |
  | {{user_id}}  | active |

# Or in raw SQL
Given "db" executes:
  """
  UPDATE users SET verified = true WHERE id = '{{user_id}}'
  """
```

## Test plan

- [ ] Verified `go build ./...` passes
- [ ] Manually tested with a project that uses HTTP + postgres steps together

